### PR TITLE
Fix bug in safari with project content size

### DIFF
--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -62,6 +62,7 @@ body {
     }
 
     &__Content {
+        position: relative;
         width: 60%;
         height: 100%;
     }


### PR DESCRIPTION
# Issue
On mac, when you open a project in the Safari browser, layout is breaking and content shows https://github.com/pshenmic/pshenmic-dev/issues/4

<img width="1157" alt="2" src="https://github.com/pshenmic/pshenmic-dev/assets/143793672/d734a55d-8624-475c-b583-b78879d694b4">

# Things done
Fixed layout styles