### PR TITLE
Fix scroll on mac and layout styles bugs

### DIFF
--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -22,7 +22,7 @@ body {
         width: 1460px;
         height: 1460px;
         background: rgba(0, 117, 255, 0.40);
-
+        z-index: -1;
         filter: blur(445.5px);
     }
     

--- a/src/components/Projects/Project.js
+++ b/src/components/Projects/Project.js
@@ -37,7 +37,7 @@ function Project ({ project, closeHandler, id }) {
             {( project.projectLink &&
               <Link 
                 className='Project__Link Project__Link--Project' 
-                href={ project.gihubLink } 
+                href={ project.projectLink } 
                 target="_blank"
               >
                 <span>Project</span>

--- a/src/components/Services/ServicesList.js
+++ b/src/components/Services/ServicesList.js
@@ -35,6 +35,7 @@ function ServicesList ({servicesList = defaultServicesList}) {
         >
             <Link 
                 href={service.link} 
+                target="_blank"
                 className='Service'
             >
                 <div className='Service__Title'>{ service.title }</div>

--- a/src/components/Updates/Updates.scss
+++ b/src/components/Updates/Updates.scss
@@ -1,7 +1,3 @@
 .Devspace {
-    @media screen and ( min-width: 500px ) and ( max-width: 680px ) {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-between;
-    }
+    
 }


### PR DESCRIPTION
# Issue
Scroll is not working in any section in Google Chrome on 2021 Macbook Pro https://github.com/pshenmic/pshenmic-dev/issues/5 

# Things done
- Added target blank attribute for services link
- Fixed scroll of content on mac
- Fixed text overflow in update section on mobile resolution 
- Fixed links in project info